### PR TITLE
Custom Validation Messages & Fixes abort in success and warn

### DIFF
--- a/src/MetApi.php
+++ b/src/MetApi.php
@@ -281,7 +281,7 @@ trait MetApi
             'type' => 'success',
             'message' => __($message, $replace),
             'data' => $data,
-        ], 200, true);
+        ], 200);
     }
 
     /**
@@ -298,7 +298,7 @@ trait MetApi
             'type' => 'warning',
             'message' => __($message, $replace),
             'data' => $data,
-        ], 200, true);
+        ], 200);
     }
 
 


### PR DESCRIPTION
By default is will use the Laravel validator messages, but now if you pass a 3rd argument like below
```php
$this
    ->option('range_1', 'required|int|between:1,5', ['between' => 'Your first range must be between :min and :max.'])
    ->option('range_2', 'required|int|between:6,10', ['between' => 'Your second range must be between :min and :max.'])
    ->verify();
```
it will use your custom message.

Also fixes issue when using `success` and `warn` from hitting exception

```php
// works
return $this->success(message: 'User was deleted', data: ['user' => $request->user()]);
```

```php
// doesnt work
  try {
      return $this->success(message: 'User was deleted', data: ['user' => $request->user()]);
  } catch (\Throwable $th) {
      // hits here
  }
```
