### PR TITLE
✨ added validation customAttributes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,10 +40,10 @@ Add the trait
 use acidjazz\metapi\MetApi;
 class Controller
 {
-    use Metapi;  
+    use Metapi;
 ```
 
-## Examples 
+## Examples
 
 ```php
 <?php
@@ -112,3 +112,41 @@ bob({
         {
 ```
 
+**Add [custom attributes](https://laravel.com/docs/9.x/validation#specifying-custom-attribute-values) to validation.**
+
+```php
+    public function send(Request $request)
+    {
+        $this->option('contact.email', 'required|email', [], 'Email Address')
+            ->option('contact.name', 'required|string', [], 'Firstname')
+            ->option('contact.surname', 'required|string', [], 'Lastname')
+            ->verify();
+        ...
+        $this->render($results);
+    }
+```
+
+`POST /send`
+
+```json
+{
+    "status": "error",
+    "errors": [
+        {
+            "status": 400,
+            "message": "contact.email",
+            "detail": "Email Address is a required field."
+        },
+        {
+            "status": 400,
+            "message": "contact.name",
+            "detail": "Firstname is a required field."
+        },
+        {
+            "status": 400,
+            "message": "contact.surname",
+            "detail": "Lastname is a required field."
+        }
+    ]
+}
+```

--- a/src/MetApi.php
+++ b/src/MetApi.php
@@ -51,7 +51,7 @@ trait MetApi
      * @param array $messages<string, string>
      * @return Controller
      */
-    public function option(string $name, array|string $rules, array $messages = []): self
+    public function option(string $name, array|string $rules, array $messages = [], string $customAttribute = null): self
     {
         $this->query['options']['rules'][$name] = $rules;
 
@@ -66,6 +66,13 @@ trait MetApi
                 $this->query['options']['messages'] ?? [],
                 ...$colMessages
             );
+        }
+
+        if ($customAttribute) {
+            if (!array_key_exists('customAttributes', $this->query['options'])) {
+                $this->query['options']['customAttributes'] = [];
+            }
+            $this->query['options']['customAttributes'][$name] = $customAttribute;
         }
 
         return $this;
@@ -150,7 +157,7 @@ trait MetApi
     public function verify($abort = true)
     {
 
-        $validate = Validator::make($this->request->all(), $this->query['options']['rules'], $this->query['options']['messages'] ?? []);
+        $validate = Validator::make($this->request->all(), $this->query['options']['rules'], $this->query['options']['messages'] ?? [], $this->query['options']['customAttributes'] ?? []);
 
         if ($validate->fails()) {
             foreach ($validate->errors()->toArray() as $key => $value) {

--- a/src/MetApi.php
+++ b/src/MetApi.php
@@ -49,6 +49,7 @@ trait MetApi
      * @param string $name
      * @param array|string $rules
      * @param array $messages<string, string>
+     * @param string $customAttribute
      * @return Controller
      */
     public function option(string $name, array|string $rules, array $messages = [], string $customAttribute = null): self


### PR DESCRIPTION
Laravel allows the use of customAttributes for validation messages.

With my pr, I added the ability to add a "customAttribute" to the option.

```php
$this->option('contact.email', 'required|email', [], 'E-Mail-Address')->verify();
```

Response without customAttributes

```json
{
    "status": "error",
    "errors": [
        {
            "status": 400,
            "message": "contact.email",
            "detail": "Contact.email ist ein Pflichtfeld."
        }
    ]
}
```

Response without customAttributes

```json
{
    "status": "error",
    "errors": [
        {
            "status": 400,
            "message": "contact.email",
            "detail": "E-Mail-Adresse ist ein Pflichtfeld."
        }
    ]
}
```